### PR TITLE
feat(behav): finish behavioral model of digital logic

### DIFF
--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -142,8 +142,9 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 4) extends Modul
   val io = IO(new UciephyTestIO(bufferDepthPerLane, numLanes))
 
   // TX registers
-  val txState = RegInit(TxTestState.idle)
-  val packetsEnqueued = RegInit(VecInit(Seq.fill(numLanes + 1)(0.U)))
+  val txReset = txFsmRst || reset.asBool
+  val txState = withReset(txReset) { RegInit(TxTestState.idle) }
+  val packetsEnqueued = withReset(txReset) { RegInit(VecInit(Seq.fill(numLanes + 1)(0.U))) }
 
   // RX registers
   val rxBitsReceived = RegInit(0.U)

--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -152,7 +152,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
   // RX registers
   val rxReset = io.mmio.rxFsmRst || reset.asBool
   val rxBitsReceived = withReset(rxReset) { RegInit(0.U((bufferDepthPerLane + 1).W)) }
-  val rxBitErrors = withReset(rxReset) { RegInit(0.U((bufferDeptherPerLane + 1).W)) }
+  val rxBitErrors = withReset(rxReset) { RegInit(0.U((bufferDepthPerLane + 1).W)) }
   val rxSignature = withReset(rxReset) { RegInit(0.U(32.W)) }
 
   val totalChunks = numLanes * (2 << (bufferDepthPerLane - 6))

--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -155,12 +155,12 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
   val rxBitErrors = withReset(rxReset) { RegInit(0.U((bufferDepthPerLane + 1).W)) }
   val rxSignature = withReset(rxReset) { RegInit(0.U(32.W)) }
 
-  val totalChunks = numLanes * (2 << (bufferDepthPerLane - 6))
+  val totalChunks = numLanes * (1 << (bufferDepthPerLane - 6))
   val addrBits = log2Ceil(totalChunks)
 
-  val inputBuffer = Reg(Vec(numLanes, Vec(2 << (bufferDepthPerLane - 6), UInt(64.W))))
-  val outputDataBuffer = Reg(Vec(numLanes, Vec(2 << (bufferDepthPerLane - 6), UInt(64.W))))
-  val outputValidBuffer = Reg(Vec(2 << (bufferDepthPerLane - 6), UInt(64.W)))
+  val inputBuffer = Reg(Vec(numLanes, Vec(1 << (bufferDepthPerLane - 6), UInt(64.W))))
+  val outputDataBuffer = Reg(Vec(numLanes, Vec(1 << (bufferDepthPerLane - 6), UInt(64.W))))
+  val outputValidBuffer = Reg(Vec(1 << (bufferDepthPerLane - 6), UInt(64.W)))
 
   // Use valid lane as reference for how many bits were sent.
   io.mmio.txBitsSent := packetsEnqueued(numLanes) << log2Ceil(Phy.DigitalBitsPerCycle)
@@ -195,7 +195,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
       }
     }
     is(TxTestState.run) {
-      val dividedInputBuffer = inputBuffer.asTypeOf(Vec(numLanes, Vec(2<<bufferDepthPerLane / Phy.DigitalBitsPerCycle, UInt(Phy.DigitalBitsPerCycle.W))))
+      val dividedInputBuffer = inputBuffer.asTypeOf(Vec(numLanes, Vec((1 << bufferDepthPerLane) / Phy.DigitalBitsPerCycle, UInt(Phy.DigitalBitsPerCycle.W))))
       for (lane <- 0 until numLanes) {
         io.phy.txTransmitData(lane).bits := dividedInputBuffer(lane)(packetsEnqueued(lane))
         io.phy.txTransmitData(lane).valid := (packetsEnqueued(lane) << log2Ceil(Phy.DigitalBitsPerCycle)) < io.mmio.txBitsToSend
@@ -268,8 +268,8 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
 
     // Insert new values into the register buffers at the appropriate offset.
     recordingStarted := recordingStarted || startRecording
-    val newOutputValidBuffer = Wire(Vec(2<<bufferDepthPerLane, Bool()))
-    val newOutputDataBuffer = Wire(Vec(numLanes, Vec(2<<bufferDepthPerLane, Bool())))
+    val newOutputValidBuffer = Wire(Vec(1 << bufferDepthPerLane, Bool()))
+    val newOutputDataBuffer = Wire(Vec(numLanes, Vec(1 << bufferDepthPerLane, Bool())))
     newOutputValidBuffer := outputValidBuffer.asTypeOf(newOutputValidBuffer)
     newOutputDataBuffer := outputDataBuffer.asTypeOf(newOutputDataBuffer)
     for (i <- 0 until Phy.DigitalBitsPerCycle) {

--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -231,7 +231,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
   
   // Only dequeue if all lanes can be dequeued simultaneously.
   val ready = (0 to numLanes).map(lane => {
-          if (lane < numLanes) { !io.phy.rxReceiveData(lane).valid } else { !io.phy.rxReceiveValid.valid }
+          if (lane < numLanes) { io.phy.rxReceiveData(lane).valid } else { io.phy.rxReceiveValid.valid }
         }).reduce(_ && _)
 
   for (lane <- 0 until numLanes) {

--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -198,7 +198,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
       val dividedInputBuffer = inputBuffer.asTypeOf(Vec(numLanes, Vec(2<<bufferDepthPerLane / Phy.DigitalBitsPerCycle, UInt(Phy.DigitalBitsPerCycle.W))))
       for (lane <- 0 until numLanes) {
         io.phy.txTransmitData(lane).bits := dividedInputBuffer(lane)(packetsEnqueued(lane))
-        io.phy.txTransmitData(lane).valid := packetsEnqueued(lane) << log2Ceil(Phy.DigitalBitsPerCycle) < io.mmio.txBitsToSend
+        io.phy.txTransmitData(lane).valid := (packetsEnqueued(lane) << log2Ceil(Phy.DigitalBitsPerCycle)) < io.mmio.txBitsToSend
       }
       switch(io.mmio.txValidFramingMode) {
         is (TxValidFramingMode.ucie) {
@@ -208,7 +208,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
           io.phy.txTransmitValid.bits := VecInit(Seq.fill(Phy.DigitalBitsPerCycle)(true.B)).asUInt
         }
       }
-      io.phy.txTransmitValid.valid := packetsEnqueued(numLanes) << log2Ceil(Phy.DigitalBitsPerCycle) < io.mmio.txBitsToSend
+      io.phy.txTransmitValid.valid := (packetsEnqueued(numLanes) << log2Ceil(Phy.DigitalBitsPerCycle)) < io.mmio.txBitsToSend
       
       for (lane <- 0 to numLanes) {
         val ready = if (lane < numLanes) { io.phy.txTransmitData(lane).ready } else { io.phy.txTransmitValid.ready }
@@ -271,7 +271,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
   newOutputValidBuffer := outputValidBuffer.asTypeOf(newOutputValidBuffer)
   newOutputDataBuffer := outputDataBuffer.asTypeOf(newOutputDataBuffer)
   for (i <- 0 until Phy.DigitalBitsPerCycle) {
-    val idx = rxBitsReceived + i.U - startIdx
+    val idx = rxBitsReceived +& i.U - startIdx
     val shouldWriteIdx = (recordingStarted || startRecording) && startIdx <= i.U
     when (shouldWriteIdx) {
       for (lane <- 0 until numLanes) {
@@ -281,7 +281,7 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
     }
   }
   when (recordingStarted || startRecording) {
-    rxBitsReceived := rxBitsReceived + Phy.DigitalBitsPerCycle.U - startIdx
+    rxBitsReceived := rxBitsReceived +& Phy.DigitalBitsPerCycle.U - startIdx
   }
   outputValidBuffer := newOutputValidBuffer.asTypeOf(outputValidBuffer)
   outputDataBuffer := newOutputDataBuffer.asTypeOf(outputDataBuffer)

--- a/src/main/scala/UciephyTest.scala
+++ b/src/main/scala/UciephyTest.scala
@@ -240,8 +240,8 @@ class UciephyTest(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extends Modul
   io.phy.rxReceiveValid.ready := ready
 
   // Dumb RX logic (only sets threshold to start recording)
-  val recordingStarted = RegInit(false.B)
-  val validHighStreak = RegInit(0.U(log2Ceil(Phy.DigitalBitsPerCycle).W))
+  val recordingStarted = withReset(rxReset) { RegInit(false.B) }
+  val validHighStreak = withReset(rxReset) { RegInit(0.U(log2Ceil(Phy.DigitalBitsPerCycle).W)) }
 
   val startRecording = Wire(Bool())
   val startIdx = Wire(UInt(log2Ceil(Phy.DigitalBitsPerCycle).W))

--- a/src/main/scala/phy/Phy.scala
+++ b/src/main/scala/phy/Phy.scala
@@ -114,7 +114,6 @@ class Phy(numLanes: Int = 2) extends Module {
 
     val rxDigitalLane = if (lane < numLanes) { io.test.rxReceiveData(lane) } else { io.test.rxReceiveValid }
     val rxDigitalLaneBits = Wire(Vec(Phy.DigitalToPhyBitsRatio, UInt(Phy.SerdesRatio.W)))
-    rxDigitalLane.bits := rxDigitalLaneBits.asTypeOf(rxDigitalLane.bits)
     val rxFifos = (0 until Phy.DigitalToPhyBitsRatio).map((i: Int) => {
       val fifo = Module(new AsyncQueue(UInt(Phy.SerdesRatio.W), Phy.QueueParams))
       rxDigitalLaneBits(i) := fifo.io.deq.bits
@@ -130,6 +129,7 @@ class Phy(numLanes: Int = 2) extends Module {
       } 
       fifo
     })
+    rxDigitalLane.bits := rxDigitalLaneBits.asTypeOf(rxDigitalLane.bits)
     rxDigitalLane.valid := rxFifos.map(_.io.deq.valid).reduce(_ && _)
 
     if (lane < numLanes) {

--- a/src/main/scala/phy/Phy.scala
+++ b/src/main/scala/phy/Phy.scala
@@ -82,7 +82,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
       fifo.io.enq.bits := txDigitalLane.bits(Phy.SerdesRatio*(i+1) - 1, Phy.SerdesRatio*i)
       fifo.io.enq.valid := txDigitalLane.valid && txDigitalLane.ready
       fifo.io.enq_clock := clock
-      fifo.io.enq_reset := reset
+      fifo.io.enq_reset := reset.asBool
       fifo.io.deq_clock := txLane.io.divClock
       fifo.io.deq_reset := !rstSyncTx.io.rstbSync.asBool
       fifo.io.deq.ready := currentFifoTx === i.U
@@ -120,7 +120,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
       rxDigitalLaneBits(i) := fifo.io.deq.bits
       fifo.io.deq.ready := rxDigitalLane.valid && rxDigitalLane.ready
       fifo.io.deq_clock := clock
-      fifo.io.deq_reset := reset
+      fifo.io.deq_reset := reset.asBool
       fifo.io.enq_clock := rxLane.io.divClock
       fifo.io.enq_reset := !rstSyncRx.io.rstbSync.asBool
       fifo.io.enq.bits := rxLane.io.dout

--- a/src/main/scala/phy/Phy.scala
+++ b/src/main/scala/phy/Phy.scala
@@ -115,7 +115,6 @@ class Phy(numLanes: Int = 4) extends Module {
     }
 
     val rxDigitalLane = if (lane < numLanes) { io.test.rxReceiveData(lane) } else { io.test.rxReceiveValid }
-    rxDigitalLane.bits := 0.U
     val rxDigitalLaneBits = Wire(Vec(Phy.DigitalToPhyBitsRatio, UInt(Phy.SerdesRatio.W)))
     rxDigitalLane.bits := rxDigitalLaneBits.asTypeOf(rxDigitalLane.bits)
     val rxFifos = (0 until Phy.DigitalToPhyBitsRatio).map((i: Int) => {

--- a/src/main/scala/phy/Phy.scala
+++ b/src/main/scala/phy/Phy.scala
@@ -11,7 +11,7 @@ object Phy {
   val QueueParams = AsyncQueueParams()
 }
 
-class PhyToTestIO(numLanes: Int = 4) extends Bundle {
+class PhyToTestIO(numLanes: Int = 2) extends Bundle {
   // Data passed in by the test RTL this cycle.
   val txTransmitData = Vec(numLanes, Flipped(DecoupledIO(UInt(Phy.DigitalBitsPerCycle.W))))
   // Valid passed in by the test RTL this cycle.
@@ -33,7 +33,7 @@ class RstSync extends Module {
   io.rstbSync := reset
 }
 
-class PhyIO(numLanes: Int = 4) extends Bundle {
+class PhyIO(numLanes: Int = 2) extends Bundle {
   // TX CONTROL
   // =====================
   // Pull-up impedance control per lane (`numLanes` data lanes, 1 valid lane, 2 clock lanes).
@@ -55,7 +55,7 @@ class PhyIO(numLanes: Int = 4) extends Bundle {
   val top = new uciephytest.UciephyTopIO(numLanes)
 }
 
-class Phy(numLanes: Int = 4) extends Module {
+class Phy(numLanes: Int = 2) extends Module {
   val io = IO(new PhyIO(numLanes))
 
   for (lane <- 0 to numLanes) {

--- a/src/main/scala/phy/Phy.scala
+++ b/src/main/scala/phy/Phy.scala
@@ -55,7 +55,7 @@ class PhyIO(numLanes: Int = 2) extends Bundle {
   val top = new uciephytest.UciephyTopIO(numLanes)
 }
 
-class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
+class Phy(numLanes: Int = 2) extends Module {
   val io = IO(new PhyIO(numLanes))
 
   for (lane <- 0 to numLanes) {
@@ -70,7 +70,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
     val rstSyncTx = withClockAndReset(txLane.io.divClock, !reset.asBool) {
       Module(new RstSync)
     }
-    val currentFifoTx  = withClock(txLane.io.divClock) {
+    val currentFifoTx  = withClockAndReset(txLane.io.divClock, reset.asAsyncReset) {
       RegInit(0.U(log2Ceil(Phy.DigitalToPhyBitsRatio).W))
     }
 
@@ -82,7 +82,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
       fifo.io.enq.bits := txDigitalLane.bits(Phy.SerdesRatio*(i+1) - 1, Phy.SerdesRatio*i)
       fifo.io.enq.valid := txDigitalLane.valid && txDigitalLane.ready
       fifo.io.enq_clock := clock
-      fifo.io.enq_reset := reset.asBool
+      fifo.io.enq_reset := reset
       fifo.io.deq_clock := txLane.io.divClock
       fifo.io.deq_reset := !rstSyncTx.io.rstbSync.asBool
       fifo.io.deq.ready := currentFifoTx === i.U
@@ -108,7 +108,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
     val rstSyncRx = withClockAndReset(rxLane.io.divClock, !reset.asBool) {
       Module(new RstSync)
     }
-    val currentFifoRx  = withClock(rxLane.io.divClock) {
+    val currentFifoRx  = withClockAndReset(rxLane.io.divClock, reset.asAsyncReset) {
       RegInit(0.U(log2Ceil(Phy.DigitalToPhyBitsRatio).W))
     }
 
@@ -120,7 +120,7 @@ class Phy(numLanes: Int = 2) extends Module with RequireAsyncReset {
       rxDigitalLaneBits(i) := fifo.io.deq.bits
       fifo.io.deq.ready := rxDigitalLane.valid && rxDigitalLane.ready
       fifo.io.deq_clock := clock
-      fifo.io.deq_reset := reset.asBool
+      fifo.io.deq_reset := reset
       fifo.io.enq_clock := rxLane.io.divClock
       fifo.io.enq_reset := !rstSyncRx.io.rstbSync.asBool
       fifo.io.enq.bits := rxLane.io.dout

--- a/src/main/scala/phy/Rx.scala
+++ b/src/main/scala/phy/Rx.scala
@@ -18,16 +18,16 @@ class RxLane extends Module {
 
   val divClock = RegInit(false.B)
   when (ctr === 0.U) {
-    divClock = !divClock
+    divClock := !divClock
   }
 
   val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
-  shiftReg := shiftReg << 1.U + din.asUInt
+  shiftReg := shiftReg << 1.U + io.din.asUInt
 
-  val outputReg = withClock(divClock) {
+  val outputReg = withClock(divClock.asClock) {
     RegNext(shiftReg)
   }
 
-  io.divClock := divClock
+  io.divClock := divClock.asClock
   io.dout := outputReg
 }

--- a/src/main/scala/phy/Rx.scala
+++ b/src/main/scala/phy/Rx.scala
@@ -13,7 +13,21 @@ class RxLaneIO extends Bundle {
 class RxLane extends Module {
   val io = IO(new RxLaneIO)
 
-  // TODO: Fix behavioral model
-  io.divClock := clock
-  io.dout := 0.U
+  val ctr = RegInit(0.U((log2Ceil(Phy.SerdesRatio) - 1).W))
+  ctr := ctr + 1.U
+
+  val divClock = RegInit(false.B)
+  when (ctr === 0.U) {
+    divClock = !divClock
+  }
+
+  val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
+  shiftReg := shiftReg << 1.U + din.asUInt
+
+  val outputReg = withClock(divClock) {
+    RegNext(shiftReg)
+  }
+
+  io.divClock := divClock
+  io.dout := outputReg
 }

--- a/src/main/scala/phy/Rx.scala
+++ b/src/main/scala/phy/Rx.scala
@@ -22,7 +22,7 @@ class RxLane extends Module {
   }
 
   val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
-  shiftReg := shiftReg << 1.U + io.din.asUInt
+  shiftReg := shiftReg << 1.U | io.din.asUInt
 
   val outputReg = withClock(divClock.asClock) {
     RegNext(shiftReg)

--- a/src/main/scala/phy/Tx.scala
+++ b/src/main/scala/phy/Tx.scala
@@ -26,13 +26,13 @@ class TxLane extends Module {
 
   val divClock = RegInit(false.B)
   when (ctr === 0.U) {
-    divClock = !divClock
+    divClock := !divClock
   }
 
   val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
   shiftReg := shiftReg >> 1.U
   when (ctr === 0.U) {
-    shiftReg := din
+    shiftReg := io.din
   }
 
   io.divClock := clock

--- a/src/main/scala/phy/Tx.scala
+++ b/src/main/scala/phy/Tx.scala
@@ -21,7 +21,20 @@ class TxLaneIO extends Bundle {
 class TxLane extends Module {
   val io = IO(new TxLaneIO)
 
-  // TODO: Fix behavioral model
+  val ctr = RegInit(0.U((log2Ceil(Phy.SerdesRatio) - 1).W))
+  ctr := ctr + 1.U
+
+  val divClock = RegInit(false.B)
+  when (ctr === 0.U) {
+    divClock = !divClock
+  }
+
+  val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
+  shiftReg := shiftReg >> 1.U
+  when (ctr === 0.U) {
+    shiftReg := din
+  }
+
   io.divClock := clock
-  io.dout := false.B
+  io.dout := shiftReg(0)
 }

--- a/src/main/scala/phy/Tx.scala
+++ b/src/main/scala/phy/Tx.scala
@@ -30,11 +30,11 @@ class TxLane extends Module {
   }
 
   val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
-  shiftReg := shiftReg >> 1.U
+  shiftReg := shiftReg << 1.U
   when (ctr === 0.U && !divClock) {
     shiftReg := io.din
   }
 
   io.divClock := divClock.asClock
-  io.dout := shiftReg(0)
+  io.dout := shiftReg(Phy.SerdesRatio - 1)
 }

--- a/src/main/scala/phy/Tx.scala
+++ b/src/main/scala/phy/Tx.scala
@@ -31,7 +31,7 @@ class TxLane extends Module {
 
   val shiftReg = RegInit(0.U(Phy.SerdesRatio.W))
   shiftReg := shiftReg >> 1.U
-  when (ctr === 0.U) {
+  when (ctr === 0.U && !divClock) {
     shiftReg := io.din
   }
 

--- a/src/main/scala/phy/Tx.scala
+++ b/src/main/scala/phy/Tx.scala
@@ -35,6 +35,6 @@ class TxLane extends Module {
     shiftReg := io.din
   }
 
-  io.divClock := clock
+  io.divClock := divClock.asClock
   io.dout := shiftReg(0)
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -141,7 +141,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
       assert((c.io.rxDataChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("cafef00d", 16))
-      c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
+      assert((c.io.rxValidChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("ffffffff", 16))
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
       c.clock.step()
@@ -150,7 +150,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
       assert((c.io.rxDataChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("deeddea1", 16))
-      c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
+      assert((c.io.rxValidChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("ffffffff", 16))
     }
   }
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -22,7 +22,7 @@ class UciephyTestHarness(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extend
 class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "UCIe PHY tester"
   it should "work" in {
-    test(new UciephyTestHarness).withAnnotations(Seq(WriteVcdAnnotation)) { c =>
+    test(new UciephyTestHarness).withAnnotations(Seq(VcsBackendAnnotation, WriteFsdbAnnotation)) { c =>
       c.clock.setTimeout(1000)
       // Set up TX
       c.io.txDataChunkIn.initSource()

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -79,6 +79,63 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.clock.step()
       c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
       c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+
+      // Try a second transmission with different parameters.
+      // c.io.txValidFramingMode.poke(TxValidFramingMode.simple)
+      // c.io.txBitsToSend.poke(128.U)
+      // c.io.txFsmRst.poke(true.B)
+      // c.clock.step()
+      // c.io.txFsmRst.poke(false.B)
+      // c.io.txTestState.expect(TxTestState.idle)
+      // c.io.txBitsSent.expect(0.U)
+
+      // // Test TX data entry
+      // c.io.txDataLane.poke(0.U)
+      // c.io.txDataOffset.poke(0.U)
+      // c.io.txDataChunkIn.enqueueNow("h1234_5678_9abc_def0".U)
+      // c.clock.step()
+      // c.io.txDataOffset.poke(1.U)
+      // c.io.txDataChunkIn.enqueueNow("hdead_beef_cafe_f00d".U)
+      // c.clock.step()
+      // c.io.txDataChunkOut.expect("h1234_5678_9abc_def0".U)
+      // c.io.txDataLane.poke(1.U)
+      // c.io.txDataChunkIn.enqueueNow("h0fed_cba9_8765_4321".U)
+      // c.clock.step()
+      // c.io.txDataChunkOut.expect("h0fed_cba9_8765_4321".U)
+      // c.io.txTestState.expect(TxTestState.idle)
+
+      // // Set up RX
+      // c.io.rxValidStartThreshold.poke(4.U)
+      // c.io.rxFsmRst.poke(true.B)
+      // c.clock.step()
+      // c.io.rxBitsReceived.expect(0.U)
+      // c.io.rxFsmRst.poke(false.B)
+      // c.clock.step()
+
+      // // Start transmitting data
+      // c.io.txExecute.poke(true.B)
+      // c.clock.step()
+      // c.io.txExecute.poke(false.B)
+      // c.io.txTestState.expect(TxTestState.run)
+
+      // // Wait until all bits are received
+      // while (c.io.rxBitsReceived.peek().litValue < 64) {
+      //   c.clock.step()
+      // }
+      // c.io.rxBitsReceived.expect(64.U)
+      // c.io.txTestState.expect(TxTestState.done)
+      // c.io.txBitsSent.expect(64.U)
+
+      // // Validate received data
+      // c.io.rxDataLane.poke(0.U)
+      // c.io.rxDataOffset.poke(0.U)
+      // c.clock.step()
+      // c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
+      // c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      // c.io.rxDataLane.poke(1.U)
+      // c.clock.step()
+      // c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
+      // c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
     }
   }
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -37,7 +37,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxFsmRst.poke(true.B)
 
       // Strobe reset
-      for (i <- 0 until 3) {
+      for (i <- 0 until 64) {
         c.clock.step()
       }
 

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -28,8 +28,8 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txDataChunkIn.initSource()
       c.io.txDataChunkIn.setSourceClock(c.clock)
       c.io.txValidFramingMode.poke(TxValidFramingMode.ucie)
-      c.io.txFsmRst.poke(true.B)
       c.io.txBitsToSend.poke(64.U)
+      c.io.txFsmRst.poke(true.B)
       c.clock.step()
       c.io.txFsmRst.poke(false.B)
       c.io.txTestState.expect(TxTestState.idle)
@@ -48,11 +48,11 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txTestState.expect(TxTestState.idle)
 
       // Set up RX
+      c.io.rxBitsReceived.expect(0.U)
+      c.io.rxValidStartThreshold.poke(4.U)
       c.io.rxFsmRst.poke(true.B)
       c.clock.step()
       c.io.rxFsmRst.poke(false.B)
-      c.io.rxBitsReceived.expect(0.U)
-      c.io.rxValidStartThreshold.poke(4.U)
       c.clock.step()
 
       // Start transmitting data

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -126,11 +126,11 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txTestState.expect(TxTestState.run)
 
       // Wait until all bits are received
-      while (c.io.rxBitsReceived.peek().litValue < 128) {
+      while (c.io.rxBitsReceived.peek().litValue < 96) {
         c.clock.step()
       }
       c.io.txTestState.expect(TxTestState.done)
-      c.io.txBitsSent.expect(128.U)
+      c.io.txBitsSent.expect(96.U)
 
       // Validate received data
       c.io.rxDataLane.poke(0.U)

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -79,15 +79,15 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxDataOffset.poke(0.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
-      c.io.rxValidChunk.expect("hf0f0_f0f0_f0f0_f0f0".U)
+      c.io.rxValidChunk.expect("h0f0f_0f0f_0f0f_0f0f".U)
       c.io.rxDataLane.poke(1.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
-      c.io.rxValidChunk.expect("hf0f0_f0f0_f0f0_f0f0".U)
+      c.io.rxValidChunk.expect("h0f0f_0f0f_0f0f_0f0f".U)
 
       // Try a second transmission with different parameters.
       c.io.txValidFramingMode.poke(TxValidFramingMode.simple)
-      c.io.txBitsToSend.poke(128.U)
+      c.io.txBitsToSend.poke(96.U)
       c.io.txFsmRst.poke(true.B)
       c.clock.step()
       c.io.txFsmRst.poke(false.B)
@@ -140,8 +140,8 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
-      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
+      c.io.rxDataChunk(31, 0).expect("hcafef00d".U)
+      c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
       c.clock.step()
@@ -149,8 +149,8 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      c.io.rxDataChunk.expect("hd00d_bead_deed_dea1".U)
-      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
+      c.io.rxDataChunk(31, 0).expect("hdeed_dea1".U)
+      c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
     }
   }
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -48,10 +48,10 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txTestState.expect(TxTestState.idle)
 
       // Set up RX
-      c.io.rxBitsReceived.expect(0.U)
       c.io.rxValidStartThreshold.poke(4.U)
       c.io.rxFsmRst.poke(true.B)
       c.clock.step()
+      c.io.rxBitsReceived.expect(0.U)
       c.io.rxFsmRst.poke(false.B)
       c.clock.step()
 

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -140,7 +140,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      c.io.rxDataChunk(31, 0).expect("hcafef00d".U)
+      assert(c.io.rxDataChunk.peek().litValue & 0xffffffff == 0xcafef00d)
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
@@ -149,7 +149,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      c.io.rxDataChunk(31, 0).expect("hdeed_dea1".U)
+      assert(c.io.rxDataChunk.peek().litValue & 0xffffffff == 0xdeeddea1)
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
     }
   }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -140,7 +140,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert(c.io.rxDataChunk.peek().litValue & 0xffffffff == 0xcafef00d)
+      assert(c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff) == BigInt(0xcafef00d))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
@@ -149,7 +149,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert(c.io.rxDataChunk.peek().litValue & 0xffffffff == 0xdeeddea1)
+      assert(c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff) == BigInt(0xdeeddea1))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
     }
   }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -22,7 +22,8 @@ class UciephyTestHarness(bufferDepthPerLane: Int = 10, numLanes: Int = 2) extend
 class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "UCIe PHY tester"
   it should "work" in {
-    test(new UciephyTestHarness).withAnnotations(Seq(VcsBackendAnnotation, WriteVcdAnnotation)) { c =>
+    test(new UciephyTestHarness).withAnnotations(Seq(WriteVcdAnnotation)) { c =>
+      c.clock.setTimeout(1000)
       // Set up TX
       c.io.txDataChunkIn.initSource()
       c.io.txDataChunkIn.setSourceClock(c.clock)
@@ -61,7 +62,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txTestState.expect(TxTestState.run)
 
       // Wait until all bits are received
-      while ((c.io.rxBitsReceived.peek() < 64.U).litToBoolean) {
+      while (c.io.rxBitsReceived.peek().litValue < 64) {
         c.clock.step()
       }
       c.io.rxBitsReceived.expect(64.U)

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -81,61 +81,63 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
 
       // Try a second transmission with different parameters.
-      // c.io.txValidFramingMode.poke(TxValidFramingMode.simple)
-      // c.io.txBitsToSend.poke(128.U)
-      // c.io.txFsmRst.poke(true.B)
-      // c.clock.step()
-      // c.io.txFsmRst.poke(false.B)
-      // c.io.txTestState.expect(TxTestState.idle)
-      // c.io.txBitsSent.expect(0.U)
+      c.io.txValidFramingMode.poke(TxValidFramingMode.simple)
+      c.io.txBitsToSend.poke(128.U)
+      c.io.txFsmRst.poke(true.B)
+      c.clock.step()
+      c.io.txFsmRst.poke(false.B)
+      c.io.txTestState.expect(TxTestState.idle)
+      c.io.txBitsSent.expect(0.U)
 
-      // // Test TX data entry
-      // c.io.txDataLane.poke(0.U)
-      // c.io.txDataOffset.poke(0.U)
-      // c.io.txDataChunkIn.enqueueNow("h1234_5678_9abc_def0".U)
-      // c.clock.step()
-      // c.io.txDataOffset.poke(1.U)
-      // c.io.txDataChunkIn.enqueueNow("hdead_beef_cafe_f00d".U)
-      // c.clock.step()
-      // c.io.txDataChunkOut.expect("h1234_5678_9abc_def0".U)
-      // c.io.txDataLane.poke(1.U)
-      // c.io.txDataChunkIn.enqueueNow("h0fed_cba9_8765_4321".U)
-      // c.clock.step()
-      // c.io.txDataChunkOut.expect("h0fed_cba9_8765_4321".U)
-      // c.io.txTestState.expect(TxTestState.idle)
+      // Test TX data entry
+      c.io.txDataLane.poke(0.U)
+      c.io.txDataOffset.poke(0.U)
+      c.io.txDataChunkIn.enqueueNow("h1234_5678_9abc_def0".U)
+      c.clock.step()
+      c.io.txDataOffset.poke(1.U)
+      c.io.txDataChunkIn.enqueueNow("hdead_beef_cafe_f00d".U)
+      c.clock.step()
+      c.io.txDataLane.poke(1.U)
+      c.io.txDataOffset.poke(0.U)
+      c.io.txDataChunkIn.enqueueNow("h0fed_cba9_8765_4321".U)
+      c.clock.step()
+      c.io.txDataOffset.poke(0.U)
+      c.io.txDataChunkIn.enqueueNow("hd00d_bead_deed_dea1".U)
+      c.clock.step()
+      c.io.txTestState.expect(TxTestState.idle)
 
-      // // Set up RX
-      // c.io.rxValidStartThreshold.poke(4.U)
-      // c.io.rxFsmRst.poke(true.B)
-      // c.clock.step()
-      // c.io.rxBitsReceived.expect(0.U)
-      // c.io.rxFsmRst.poke(false.B)
-      // c.clock.step()
+      // Set up RX
+      c.io.rxValidStartThreshold.poke(4.U)
+      c.io.rxFsmRst.poke(true.B)
+      c.clock.step()
+      c.io.rxBitsReceived.expect(0.U)
+      c.io.rxFsmRst.poke(false.B)
+      c.clock.step()
 
-      // // Start transmitting data
-      // c.io.txExecute.poke(true.B)
-      // c.clock.step()
-      // c.io.txExecute.poke(false.B)
-      // c.io.txTestState.expect(TxTestState.run)
+      // Start transmitting data
+      c.io.txExecute.poke(true.B)
+      c.clock.step()
+      c.io.txExecute.poke(false.B)
+      c.io.txTestState.expect(TxTestState.run)
 
-      // // Wait until all bits are received
-      // while (c.io.rxBitsReceived.peek().litValue < 64) {
-      //   c.clock.step()
-      // }
-      // c.io.rxBitsReceived.expect(64.U)
-      // c.io.txTestState.expect(TxTestState.done)
-      // c.io.txBitsSent.expect(64.U)
+      // Wait until all bits are received
+      while (c.io.rxBitsReceived.peek().litValue < 64) {
+        c.clock.step()
+      }
+      c.io.rxBitsReceived.expect(64.U)
+      c.io.txTestState.expect(TxTestState.done)
+      c.io.txBitsSent.expect(64.U)
 
-      // // Validate received data
-      // c.io.rxDataLane.poke(0.U)
-      // c.io.rxDataOffset.poke(0.U)
-      // c.clock.step()
-      // c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
-      // c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
-      // c.io.rxDataLane.poke(1.U)
-      // c.clock.step()
-      // c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
-      // c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      // Validate received data
+      c.io.rxDataLane.poke(0.U)
+      c.io.rxDataOffset.poke(0.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
+      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxDataLane.poke(1.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
+      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
     }
   }
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -65,7 +65,6 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       while (c.io.rxBitsReceived.peek().litValue < 64) {
         c.clock.step()
       }
-      c.io.rxBitsReceived.expect(64.U)
       c.io.txTestState.expect(TxTestState.done)
       c.io.txBitsSent.expect(64.U)
 
@@ -124,7 +123,6 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       while (c.io.rxBitsReceived.peek().litValue < 128) {
         c.clock.step()
       }
-      c.io.rxBitsReceived.expect(128.U)
       c.io.txTestState.expect(TxTestState.done)
       c.io.txBitsSent.expect(128.U)
 

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -1,0 +1,99 @@
+package uciephytest
+
+import chisel3._
+import chisel3.experimental.VecLiterals.AddObjectLiteralConstructor
+import chiseltest._
+import freechips.rocketchip.util.AsyncQueueParams
+import org.scalatest.flatspec.AnyFlatSpec
+import interfaces._
+
+class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "UCIe PHY tester"
+  it should "work" in {
+    test(new UciephyTest(bufferDepthPerLane = 10, numLanes = 2)) { c =>
+      // Set up TX
+      c.io.txDataChunkIn.initSource()
+      c.io.txData.setSourceClock(c.clock)
+      c.io.txValidFramingMode.poke(TxValidFramingMode.ucie)
+      c.io.txFsmRst.poke(true.B)
+      c.io.txBitsToSend.poke(64.U)
+      c.clock.step()
+      c.io.txFsmRst.poke(false.B)
+      c.io.txTestState.expect(TxTestState.idle)
+      c.io.txBitsSent.expect(0.U)
+
+      // Test TX data entry
+      c.io.txDataLane.poke(0.U)
+      c.io.txDataOffset.poke(0.U)
+      c.io.txDataChunkIn.enqueueNow("h1234_5678_9abc_def0".U)
+      c.clock.step()
+      c.io.txDataChunkOut.expect("h1234_5678_9abc_def0".U)
+      c.io.txDataLane.poke(1.U)
+      c.io.txDataChunkIn.enqueueNow("h0fed_cba9_8765_4321".U)
+      c.clock.step()
+      c.io.txDataChunkOut.expect("h0fed_cba9_8765_4321".U)
+      c.io.txTestState.expect(TxTestState.idle)
+
+      // Set up RX
+      c.io.rxFsmRst.poke(true.B)
+      c.clock.step()
+      c.io.rxFsmRst.poke(false.B)
+      c.io.rxBitsReceived.expect(0.U)
+      c.io.rxValidStartThreshold.poke(4.U)
+      c.clock.step()
+
+      // Start transmitting data
+      c.io.txExecute.poke(true.B)
+      c.clock.step()
+      c.io.txExecute.poke(false.B)
+      c.io.txTestState.expect(TxTestState.run)
+
+      // Wait until all bits are received
+      while (c.io.rxBitsReceived.peek() < 64) {
+        c.clock.step()
+      }
+      c.io.rxBitsReceived.expect(64.U)
+      c.io.txTestState.expect(TxTestState.done)
+      c.io.txBitsSent.expect(64.U)
+
+      // Validate received data
+      c.io.rxDataLane.poke(0.U)
+      c.io.rxDataOffset.poke(0.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
+      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxDataLane.poke(1.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
+      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+
+
+
+
+      c.io.mainbandLaneIO.txData.enqueueNow(
+        "h1234_5678_9abc_def0_0fed_cba9_8765_4321_1111_2222_3333_4444_5555_6666_7777_8888".U,
+      )
+      c.io.mainbandIo.txData
+        .expectDequeueNow(
+          Vec.Lit(
+            "h1211".U,
+            "h3411".U,
+            "h5622".U,
+            "h7822".U,
+            "h9a33".U,
+            "hbc33".U,
+            "hde44".U,
+            "hf044".U,
+            "h0f55".U,
+            "hed55".U,
+            "hcb66".U,
+            "ha966".U,
+            "h8777".U,
+            "h6577".U,
+            "h4388".U,
+            "h2188".U,
+          ),
+        )
+    }
+  }
+}

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -74,11 +74,11 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxDataOffset.poke(0.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
-      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxValidChunk.expect("hf0f0_f0f0_f0f0_f0f0".U)
       c.io.rxDataLane.poke(1.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
-      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxValidChunk.expect("hf0f0_f0f0_f0f0_f0f0".U)
 
       // Try a second transmission with different parameters.
       c.io.txValidFramingMode.poke(TxValidFramingMode.simple)
@@ -101,13 +101,13 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txDataOffset.poke(0.U)
       c.io.txDataChunkIn.enqueueNow("h0fed_cba9_8765_4321".U)
       c.clock.step()
-      c.io.txDataOffset.poke(0.U)
+      c.io.txDataOffset.poke(1.U)
       c.io.txDataChunkIn.enqueueNow("hd00d_bead_deed_dea1".U)
       c.clock.step()
       c.io.txTestState.expect(TxTestState.idle)
 
       // Set up RX
-      c.io.rxValidStartThreshold.poke(4.U)
+      c.io.rxValidStartThreshold.poke(1.U)
       c.io.rxFsmRst.poke(true.B)
       c.clock.step()
       c.io.rxBitsReceived.expect(0.U)
@@ -121,23 +121,32 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.txTestState.expect(TxTestState.run)
 
       // Wait until all bits are received
-      while (c.io.rxBitsReceived.peek().litValue < 64) {
+      while (c.io.rxBitsReceived.peek().litValue < 128) {
         c.clock.step()
       }
-      c.io.rxBitsReceived.expect(64.U)
+      c.io.rxBitsReceived.expect(128.U)
       c.io.txTestState.expect(TxTestState.done)
-      c.io.txBitsSent.expect(64.U)
+      c.io.txBitsSent.expect(128.U)
 
       // Validate received data
       c.io.rxDataLane.poke(0.U)
       c.io.rxDataOffset.poke(0.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
-      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
+      c.io.rxDataOffset.poke(1.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("h1234_5678_9abc_def0".U)
+      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
+      c.io.rxDataOffset.poke(0.U)
       c.clock.step()
       c.io.rxDataChunk.expect("h0fed_cba9_8765_4321".U)
-      c.io.rxValidChunk.expect("h1010_1010_1010_1010".U)
+      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
+      c.io.rxDataOffset.poke(1.U)
+      c.clock.step()
+      c.io.rxDataChunk.expect("hd00d_bead_deed_dea1".U)
+      c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
     }
   }
 }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -140,7 +140,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert(c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff) == BigInt(0xcafef00d))
+      assert((c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff)) == BigInt(0xcafef00d))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
@@ -149,7 +149,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert(c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff) == BigInt(0xdeeddea1))
+      assert((c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff)) == BigInt(0xdeeddea1))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
     }
   }

--- a/src/test/scala/UciephyTestSpec.scala
+++ b/src/test/scala/UciephyTestSpec.scala
@@ -140,7 +140,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert((c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff)) == BigInt(0xcafef00d))
+      assert((c.io.rxDataChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("cafef00d", 16))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
       c.io.rxDataLane.poke(1.U)
       c.io.rxDataOffset.poke(0.U)
@@ -149,7 +149,7 @@ class UciephyTestSpec extends AnyFlatSpec with ChiselScalatestTester {
       c.io.rxValidChunk.expect("hffff_ffff_ffff_ffff".U)
       c.io.rxDataOffset.poke(1.U)
       c.clock.step()
-      assert((c.io.rxDataChunk.peek().litValue & BigInt(0xffffffff)) == BigInt(0xdeeddea1))
+      assert((c.io.rxDataChunk.peek().litValue & BigInt("ffffffff", 16)) == BigInt("deeddea1", 16))
       c.io.rxValidChunk.expect("h0000_0000_ffff_ffff".U)
     }
   }


### PR DESCRIPTION
- **remove unecessary assignment**
- **add dumb RX logic**
- **finish up RX logic and start adding tests**
- **fix tests**
- **make elaboration faster and fix buffers**
- **set timeout and use litValue instead of hardware**
- **use vcs backend with fsdb output**
- **explicitly declare register widths**
- **fix typo**
- **fix potential addition errors**
- **set parameters then reset**
- **fix assertion**
- **reset all RX related registers correctly**
- **fix ready signal**
- **add second transmission**
- **remove unecessary assertion**
- **only increment counters if packet is queued/dequeued**
- **strobe reset first**
- **strobe reset for longer**
- **use async reset for phy registers**
- **try fixing reset issues**
- **use async reset only for problematic registers**
- **fix tx behavioral model bug**
- **serialize MSB first**
- **add more interesting tests**
- **fix test**
- **fix hardware in scalatest**
- **use bigint**
- **fix order of operations**
- **fix overflow issues**
- **fix valid checks**
